### PR TITLE
Changes to README.md to include missing Twitter creds and valid servi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,25 @@ access_token_secret=<twitter token secret>
 
 ```
 $ docker service create --name tweetlistener \
-  --env-file tweetlistener.envs
-  --image developius/tweetlistener:latest
-  --network func_functions
+  --env-file tweetlistener.envs \
+  --network func_functions \
+  developius/tweetlistener:latest
 ```
+
+Update `credentials.yml` to add your Twitter details
+
+```yaml
+environment:
+  minio_secret_key: <minio secret key>
+  minio_access_key: <minio access key>
+  minio_url: <minio url>
+  consumer_key: <twitter consumer key>
+  consumer_secret: <twitter consumer secret>
+  access_token: <twitter token>
+  access_token_secret: <twitter token secret>
+```
+
+Then re-deploy
 
 ```
 $ faas-cli deploy -f twitter_stack.yml


### PR DESCRIPTION
Changes to README.md to include missing Twitter creds and valid service create command.

Signed-off-by: rgee0 <richard@technologee.co.uk>

On testing I found that docker service create didn't like the `--image` flag.  The command usage is:
`Usage:	docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]`

Also the tweetpic function is using `credentials.yml` with only Minio details contained.  The code within tweetpic is expecting twitter credentials in order to tweet the colourized image.  I have added instructions to amend `credentials.yml` to include the necessary.  There was a choice here to create a further `.yml` file just for `tweetpic`, or reuse the the existing file and see the Twitter details also being made available in colourise.  I favoured limiting duplication.