### PR TITLE
Fix bug occurring when trailing newline characters are used with url_mode

### DIFF
--- a/colorization/handler.py
+++ b/colorization/handler.py
@@ -23,7 +23,10 @@ def nostdout():
     sys.stdout = save_stdout
 
 def download_file(url, save_path):
-    r = requests.get(url, stream=True)
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36'
+    }
+    r = requests.get(url, stream=True, headers=headers)
     with open(save_path, 'wb') as f:
         shutil.copyfileobj(r.raw, f)
 

--- a/colorization/index.py
+++ b/colorization/index.py
@@ -21,8 +21,14 @@ def read_head():
 
 if(__name__ == "__main__"):
     binary_mode = os.getenv('minio_authority') == None
+    url_mode = os.getenv('url_mode') != None
+
     if binary_mode == True:
         st = sys.stdin.read()
+
+        if url_mode:
+            st = st.strip("\\n") # fix for leading/trailing whitespace in URLs
+
         handler.handle(st)
     else:
         st = get_stdin()

--- a/stack.yml
+++ b/stack.yml
@@ -6,7 +6,7 @@ functions:
   colorization:
     lang: Dockerfile
     handler: ./colorization
-    image: alexellis2/openfaas-colorization:0.4.0
+    image: alexellis2/openfaas-colorization:0.4.1
     environment:
       read_timeout: 60
       write_timeout: 60


### PR DESCRIPTION
- trim trailing newline characters from the URL in url_mode (was creating invalid URLs)
- add a default user agent to download files without triggering WAFs etc

Thanks to @vielmetti for helping to identify the issues 👍 

Signed-off-by: Finnian Anderson <get@finnian.io>